### PR TITLE
Update dependencies in the ruby client

### DIFF
--- a/clients/ruby/.commit/config.yml
+++ b/clients/ruby/.commit/config.yml
@@ -56,5 +56,5 @@ ruby:
         spec.require_path = "lib"
 
         spec.add_dependency "core-async", "~> 0.5.0"
-        spec.add_dependency "http", "~> 4.4"
+        spec.add_dependency "http", "~> 5.0"
         spec.add_dependency "msgpack", "~> 1.4"

--- a/clients/ruby/proc.gemspec
+++ b/clients/ruby/proc.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_path = "lib"
 
   spec.add_dependency "core-async", "~> 0.5.0"
-  spec.add_dependency "http", "~> 4.4"
+  spec.add_dependency "http", "~> 5.0"
   spec.add_dependency "msgpack", "~> 1.4"
 end


### PR DESCRIPTION
Just bumps `http` so we get better performance/portability via [llhttp](https://github.com/metabahn/llhttp).