### PR TITLE
Introduce global authorization/instance to the Ruby client

### DIFF
--- a/clients/ruby/.commit/config.yml
+++ b/clients/ruby/.commit/config.yml
@@ -56,5 +56,6 @@ ruby:
         spec.require_path = "lib"
 
         spec.add_dependency "core-async", "~> 0.6"
+        spec.add_dependency "core-global", "~> 0.0"
         spec.add_dependency "http", "~> 5.0"
         spec.add_dependency "msgpack", "~> 1.4"

--- a/clients/ruby/proc.gemspec
+++ b/clients/ruby/proc.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_path = "lib"
 
   spec.add_dependency "core-async", "~> 0.6"
+  spec.add_dependency "core-global", "~> 0.0"
   spec.add_dependency "http", "~> 5.0"
   spec.add_dependency "msgpack", "~> 1.4"
 end

--- a/clients/ruby/spec/features/globalized_spec.rb
+++ b/clients/ruby/spec/features/globalized_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "support/context/acceptance"
+
+RSpec.describe "ruby client api: using the global instance" do
+  include_context "acceptance"
+
+  before do
+    ENV["PROC_AUTH"] = authorization
+    Proc::Client.reset
+  end
+
+  after do
+    ENV.delete("PROC_AUTH")
+  end
+
+  it "can call proc" do
+    expect(Proc::Client.core.echo.call(123)).to eq(123)
+  end
+
+  describe "authorization" do
+    context "PROC_AUTH environment variable is not defined" do
+      before do
+        ENV.delete("PROC_AUTH")
+      end
+
+      context "proc auth file exists" do
+        before do
+          replace_auth_file
+        end
+
+        after do
+          restore_auth_file
+        end
+
+        it "uses the proc auth file" do
+          expect(Proc::Client.core.echo.call(123)).to eq(123)
+        end
+      end
+
+      context "proc auth file does not exist" do
+        before do
+          remove_auth_file
+        end
+
+        after do
+          restore_auth_file
+        end
+
+        it "fails to authorize" do
+          expect {
+            Proc::Client.core.echo.call(123)
+          }.to raise_error(Proc::Unauthorized)
+        end
+      end
+    end
+
+    context "PROC_AUTH environment variable is defined" do
+      context "proc auth file exists" do
+        before do
+          replace_auth_file("invalid")
+        end
+
+        after do
+          restore_auth_file
+        end
+
+        it "prefers the environment variable" do
+          expect(Proc::Client.core.echo.call(123)).to eq(123)
+        end
+      end
+    end
+  end
+end

--- a/clients/ruby/spec/features/support/context/acceptance.rb
+++ b/clients/ruby/spec/features/support/context/acceptance.rb
@@ -17,4 +17,38 @@ RSpec.shared_context "acceptance" do
   let(:authorization) {
     ENV.fetch("SECRET")
   }
+
+  def remove_auth_file
+    backup_auth_file
+
+    FileUtils.rm_f(auth_file_path)
+  end
+
+  def replace_auth_file(contents = authorization)
+    backup_auth_file
+
+    FileUtils.mkdir_p(auth_file_path.dirname)
+
+    auth_file_path.open("w+") do |file|
+      file.write(contents)
+    end
+  end
+
+  def restore_auth_file
+    if defined?(@existing_auth_file_contents)
+      auth_file_path.open("w+") do |file|
+        file.write(@existing_auth_file_contents)
+      end
+    end
+  end
+
+  def backup_auth_file
+    if auth_file_path.exist?
+      @existing_auth_file_contents = auth_file_path.read
+    end
+  end
+
+  def auth_file_path
+    @_auth_file_path ||= Pathname.new("~/.proc/auth").expand_path
+  end
 end


### PR DESCRIPTION
This PR makes it possible to authorize the Ruby client through an environment variable or authfile. Proc now looks for an authorization in the `PROC_AUTH` environment variable, falling back to `~/.proc/auth` if it exists. When using one of these global authorization strategies, you no longer have to pass the authorization to `Proc::Client::new`:

```ruby
client = Proc::Client.new
```

This PR also turns `Proc::Client` into a global instance:

```ruby
Proc::Client.core.echo("foo")
# => "foo"
```

The global instance can only be used with one of the above global authorization strategies.