### PR TITLE
Add a new client object for generating Proc ASTs in Ruby

### DIFF
--- a/clients/ruby/lib/proc.rb
+++ b/clients/ruby/lib/proc.rb
@@ -7,8 +7,8 @@ class Proc
   class << self
     # [public] Connect a client with an authorization.
     #
-    def connect(authorization, **options)
-      Client.new(authorization, **options)
+    def connect(authorization, client: Proc::Client, **options)
+      client.new(authorization, **options)
     end
   end
 end

--- a/clients/ruby/lib/proc/client.rb
+++ b/clients/ruby/lib/proc/client.rb
@@ -171,6 +171,10 @@ class Proc
         body << ["$$", key.to_s, serialize_value(value)]
       end
 
+      process(proc: proc, body: body, input: input, arguments: arguments, &block)
+    end
+
+    private def process(proc:, body:, input:, arguments:, &block)
       status, headers, payload = get_payload(proc: proc, body: body)
 
       case status

--- a/clients/ruby/lib/proc/clients/ast.rb
+++ b/clients/ruby/lib/proc/clients/ast.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "../client"
+
+class Proc
+  module Clients
+    # [public] Returns an ast that can be passed to `core.exec`.
+    #
+    class AST < Client
+      private def process(proc:, body:, **)
+        unless proc == "core.exec"
+          body = [["$$", "proc", ["{}", ["()", proc].concat(body)]]]
+        end
+
+        body
+      end
+    end
+  end
+end

--- a/clients/ruby/spec/features/ast_spec.rb
+++ b/clients/ruby/spec/features/ast_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "support/context/acceptance"
+
+require "proc/clients/ast"
+
+RSpec.describe "ruby client api: building asts" do
+  include_context "acceptance"
+
+  let(:client_class) {
+    Proc::Clients::AST
+  }
+
+  it "builds the ast for simple calls" do
+    expect(client.core.echo("foo").call).to eq([["$$", "proc", ["{}", ["()", "core.echo", [">>", ["%%", "foo"]]]]]])
+  end
+
+  it "builds the ast for compositions" do
+    expect((client.core.echo("foo") >> client.core.echo).call).to eq(
+      [
+        [
+          "$$", "proc", [
+            "{}",
+            [">>", ["%%", "foo"]],
+            ["()", "core.echo", [">>", ["%%", "foo"]]],
+            ["()", "core.echo"]
+          ]
+        ]
+      ]
+    )
+  end
+end

--- a/clients/ruby/spec/features/support/context/acceptance.rb
+++ b/clients/ruby/spec/features/support/context/acceptance.rb
@@ -7,11 +7,15 @@ Dotenv.load
 
 RSpec.shared_context "acceptance" do
   let(:client) {
-    Proc.connect(authorization, **client_options)
+    Proc.connect(authorization, client: client_class, **client_options)
   }
 
   let(:client_options) {
     {}
+  }
+
+  let(:client_class) {
+    Proc::Client
   }
 
   let(:authorization) {


### PR DESCRIPTION
This PR introduces a `Proc::Clients::AST` object that returns an AST passable to `core.exec`.

```ruby
require "proc/clients/ast"

client = Proc.connect(client: Proc::Clients::AST)

client.core.echo("foo").call
# => [["$$", "proc", ["{}", ["()", "core.echo", [">>", ["%%", "foo"]]]]]]
```

Includes a supporting change to `Proc::connect` allowing the client class to be passed as a keyword argument.