### PR TITLE
Prefer duck typing for serialization

### DIFF
--- a/clients/ruby/lib/proc/client.rb
+++ b/clients/ruby/lib/proc/client.rb
@@ -220,7 +220,9 @@ class Proc
       end
     end
 
-    IGNORE_MISSING = %i[].freeze
+    IGNORE_MISSING = %i[
+    ].freeze
+
     KERNEL_DELEGATE = %i[
       class
       instance_variables
@@ -228,6 +230,7 @@ class Proc
       instance_variable_set
       object_id
       public_send
+      respond_to?
     ].freeze
 
     # [public] Allows callable contexts to be built through method lookups.
@@ -274,10 +277,12 @@ class Proc
       case value
       when ::Symbol
         ["@@", value.to_s, {}]
-      when ::Proc::Composer::Argument, ::Proc::Callable, ::Proc::Composition
-        value.serialize
       else
-        ["%%", value]
+        if value.respond_to?(:serialize)
+          value.serialize
+        else
+          ["%%", value]
+        end
       end
     end
 

--- a/composer/ruby/lib/proc/composer/callable.rb
+++ b/composer/ruby/lib/proc/composer/callable.rb
@@ -90,7 +90,10 @@ class Proc
         build_callable(proc: [@proc, proc].join("."), input: @input, arguments: arguments)
       end
 
-      IGNORE_MISSING = %i[to_hash].freeze
+      IGNORE_MISSING = %i[
+        to_hash
+      ].freeze
+
       KERNEL_DELEGATE = %i[
         class
         instance_variables
@@ -98,6 +101,7 @@ class Proc
         instance_variable_set
         object_id
         public_send
+        respond_to?
       ].freeze
 
       # [public] Allows nested callable contexts to be built through method lookups.
@@ -136,10 +140,12 @@ class Proc
         case value
         when ::Symbol
           ["@@", value.to_s, {}]
-        when ::Proc::Composer::Argument, ::Proc::Composer::Callable, ::Proc::Composer::Composition
-          value.serialize
         else
-          ["%%", value]
+          if value.respond_to?(:serialize)
+            value.serialize
+          else
+            ["%%", value]
+          end
         end
       end
 

--- a/composer/ruby/lib/proc/composer/composition.rb
+++ b/composer/ruby/lib/proc/composer/composition.rb
@@ -91,10 +91,12 @@ class Proc
         case value
         when Symbol
           ["@@", value.to_s, {}]
-        when Argument, Callable, Composition
-          value.serialize
         else
-          ["%%", value]
+          if value.respond_to?(:serialize)
+            value.serialize
+          else
+            ["%%", value]
+          end
         end
       end
 


### PR DESCRIPTION
This makes it much easier to add serialization to custom code that might extend `proc`.